### PR TITLE
allow adding hostnames

### DIFF
--- a/certs.sh
+++ b/certs.sh
@@ -3,7 +3,7 @@
 if [ -n "$CERTS" ]; then
     certbot certonly --no-self-upgrade -n --text --standalone \
         --standalone-supported-challenges http-01 \
-        -d "$CERTS" --keep --agree-tos --email "$EMAIL" \
+        -d "$CERTS" --keep --expand --agree-tos --email "$EMAIL" \
         || exit 1
 fi
 


### PR DESCRIPTION
I added the --expand option so that new hostnames can be added.
Without this option when having --keep enabled, letsencrypt says that some of the hostnames are already covered by a cert and refuses to generate a new one.
